### PR TITLE
[feature] 유저프로필 화면 (유저정보 받기, 팔로워/팔로잉화면 추가)

### DIFF
--- a/app/src/main/java/com/cokiri/coinkiri/data/local/database/AppDatabase.kt
+++ b/app/src/main/java/com/cokiri/coinkiri/data/local/database/AppDatabase.kt
@@ -5,7 +5,9 @@ import androidx.room.RoomDatabase
 import com.cokiri.coinkiri.data.local.dao.MemberInfoDao
 import com.cokiri.coinkiri.data.local.entity.MemberInfoEntity
 
-@Database(entities = [MemberInfoEntity::class], version = 1)
+@Database(entities = [MemberInfoEntity::class], version = 3, exportSchema = false)
 abstract class AppDatabase : RoomDatabase() {
     abstract fun memberInfoDao(): MemberInfoDao
+
+
 }

--- a/app/src/main/java/com/cokiri/coinkiri/data/local/entity/MemberInfoEntity.kt
+++ b/app/src/main/java/com/cokiri/coinkiri/data/local/entity/MemberInfoEntity.kt
@@ -10,5 +10,8 @@ data class MemberInfoEntity(
     val exp: Int,
     val level: Int,
     val mileage: Int,
-    val pic: String?
+    val pic: String?,
+    val statusMessage: String,
+    val followingCount: Int,
+    val followerCount: Int
 )

--- a/app/src/main/java/com/cokiri/coinkiri/data/remote/model/MemberResponse.kt
+++ b/app/src/main/java/com/cokiri/coinkiri/data/remote/model/MemberResponse.kt
@@ -17,5 +17,8 @@ data class MemberInfo(
     val exp : Int,
     val level : Int,
     val mileage : Int,
-    val pic : String?
+    val pic : String?,
+    val statusMessage : String,
+    val followingCount : Int,
+    val followerCount : Int
 )

--- a/app/src/main/java/com/cokiri/coinkiri/data/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/cokiri/coinkiri/data/repository/UserRepositoryImpl.kt
@@ -88,7 +88,10 @@ class UserRepositoryImpl @Inject constructor(
                         exp = result.exp,
                         level = result.level,
                         mileage = result.mileage,
-                        pic = result.pic
+                        pic = result.pic,
+                        statusMessage = result.statusMessage,
+                        followingCount = result.followingCount,
+                        followerCount = result.followerCount
                     )
                     insertMemberInfo(memberInfoEntity)
                     memberInfoEntity

--- a/app/src/main/java/com/cokiri/coinkiri/di/DatabaseModule.kt
+++ b/app/src/main/java/com/cokiri/coinkiri/di/DatabaseModule.kt
@@ -2,6 +2,8 @@ package com.cokiri.coinkiri.di
 
 import android.content.Context
 import androidx.room.Room
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 import com.cokiri.coinkiri.data.local.dao.MemberInfoDao
 import com.cokiri.coinkiri.data.local.database.AppDatabase
 import dagger.Module
@@ -15,6 +17,21 @@ import javax.inject.Singleton
 @InstallIn(SingletonComponent::class)
 object DatabaseModule {
 
+    private val MIGRATION_1_2 = object : Migration(1, 2) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            // 스키마 변경에 따른 SQL 쿼리 작성
+            db.execSQL("ALTER TABLE member_info ADD COLUMN statusMessage TEXT")
+        }
+    }
+
+    private val MIGRATION_2_3 = object : Migration(2, 3) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            // 스키마 변경에 따른 SQL 쿼리 작성
+            db.execSQL("ALTER TABLE member_info ADD COLUMN followingCount INTEGER DEFAULT 0 NOT NULL")
+            db.execSQL("ALTER TABLE member_info ADD COLUMN followerCount INTEGER DEFAULT 0 NOT NULL")
+        }
+    }
+
     @Provides
     @Singleton
     fun provideDatabase(@ApplicationContext appContext: Context): AppDatabase {
@@ -22,7 +39,9 @@ object DatabaseModule {
             appContext,
             AppDatabase::class.java,
             "coinkiri_database"
-        ).build()
+        )
+        .addMigrations(MIGRATION_1_2, MIGRATION_2_3)
+        .build()
     }
 
     @Provides

--- a/app/src/main/java/com/cokiri/coinkiri/presentation/login/LoginScreen.kt
+++ b/app/src/main/java/com/cokiri/coinkiri/presentation/login/LoginScreen.kt
@@ -17,13 +17,13 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import com.cokiri.coinkiri.R
+import com.cokiri.coinkiri.ui.theme.kakaoColor
 import com.cokiri.coinkiri.util.HOME
 import com.cokiri.coinkiri.util.LOGIN
 
@@ -74,7 +74,7 @@ fun KakaoLoginBtn(
 ) {
     Card(
         onClick = { onClick() },
-        colors = CardDefaults.cardColors(Color.Yellow),
+        colors = CardDefaults.cardColors(kakaoColor),
         elevation = CardDefaults.cardElevation(pressedElevation = 3.dp),
         modifier = Modifier
             .height(50.dp)

--- a/app/src/main/java/com/cokiri/coinkiri/presentation/profile/FollowScreen.kt
+++ b/app/src/main/java/com/cokiri/coinkiri/presentation/profile/FollowScreen.kt
@@ -1,0 +1,73 @@
+package com.cokiri.coinkiri.presentation.profile
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.navigation.NavHostController
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun FollowScreen(navController: NavHostController) {
+    var selectedTabIndex by remember { mutableIntStateOf(0) }
+    val tabs = listOf("팔로워", "팔로잉")
+
+    Column {
+        TopAppBar(
+            title = { Text("팔로워 / 팔로잉") },
+            navigationIcon = {
+                IconButton(onClick = { navController.popBackStack() }) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = "뒤로가기"
+                    )
+                }
+            }
+        )
+
+        TabRow(selectedTabIndex = selectedTabIndex) {
+            tabs.forEachIndexed { index, title ->
+                Tab(
+                    selected = selectedTabIndex == index,
+                    onClick = { selectedTabIndex = index },
+                    text = { Text(title) }
+                )
+            }
+        }
+
+        when (selectedTabIndex) {
+            0 -> FollowersList()
+            1 -> FollowingList()
+        }
+    }
+}
+
+@Composable
+fun FollowersList() {
+    LazyColumn {
+        items(30) {
+            Text(text = "Follower") // Replace with your followers item UI
+        }
+    }
+}
+
+@Composable
+fun FollowingList() {
+    LazyColumn {
+        items(30) {
+            Text(text = "Following") // Replace with your following item UI
+        }
+    }
+}

--- a/app/src/main/java/com/cokiri/coinkiri/presentation/profile/MemberInfoCard.kt
+++ b/app/src/main/java/com/cokiri/coinkiri/presentation/profile/MemberInfoCard.kt
@@ -1,0 +1,165 @@
+package com.cokiri.coinkiri.presentation.profile
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.CutCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.rememberNavController
+import com.cokiri.coinkiri.R
+import com.cokiri.coinkiri.data.local.entity.MemberInfoEntity
+import com.cokiri.coinkiri.ui.theme.CoinkiriBackground
+import com.cokiri.coinkiri.util.FOLLOW
+import com.cokiri.coinkiri.util.PROFILE
+
+@Composable
+fun MemberInfoCard(
+    memberInfo: MemberInfoEntity?,
+    navController: NavHostController
+) {
+
+
+
+    Card(
+        modifier = Modifier
+            .fillMaxWidth(1f)
+            .padding(10.dp),
+        colors = CardDefaults.cardColors(CoinkiriBackground),
+        shape = CardDefaults.shape,
+        elevation = CardDefaults.cardElevation(5.dp)
+    ) {
+
+        Column(
+            modifier = Modifier
+                .fillMaxWidth(1f)
+                .padding(15.dp),
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth(1f)
+                    .padding(5.dp),
+                verticalAlignment = Alignment.Bottom
+            ) {
+                Card(
+                    shape = CircleShape,
+                    elevation = CardDefaults.cardElevation(5.dp),
+                ) {
+                    Image(
+                        painter = painterResource(id = R.drawable.ic_launcher_foreground),
+                        contentScale = ContentScale.Crop,
+                        contentDescription = "Profile Image",
+                        modifier = Modifier
+                            .size(50.dp)
+                    )
+                }
+
+                Column(
+                    modifier = Modifier
+                        .padding(start = 10.dp, bottom = 5.dp),
+                    verticalArrangement = Arrangement.spacedBy(1.dp)
+                ) {
+                    if (memberInfo != null) {
+                        Text(
+                            text = "Lv." + memberInfo.level.toString(),
+                        )
+                        Text(
+                            text = memberInfo.nickname,
+                            fontWeight = FontWeight.Bold,
+                        )
+                    }
+                }
+            }
+
+            Surface(
+                modifier = Modifier
+                    .fillMaxWidth(1f)
+                    .padding(vertical = 15.dp, horizontal = 10.dp),
+                shape = CutCornerShape(topEnd = 10.dp),
+            ) {
+                if (memberInfo != null) {
+                    Text(
+                        text = memberInfo.statusMessage,
+                        modifier = Modifier
+                            .padding(5.dp)
+                    )
+                }
+            }
+        }
+
+        Row(
+            modifier = Modifier
+                .background(Color.LightGray)
+                .fillMaxWidth(1f),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceEvenly
+        ){
+            TextButton(
+                onClick = {navController.navigate(FOLLOW)},
+                text = "팔로워"
+            )
+            TextButton(
+                onClick = {navController.navigate(FOLLOW)},
+                text = "팔로잉"
+            )
+        }
+    }
+}
+
+
+
+@Composable
+fun TextButton(
+    onClick: () -> Unit,
+    text: String
+) {
+    TextButton(
+        onClick = onClick,
+    ) {
+        Text(
+            text = "$text 0",
+        )
+    }
+}
+
+@Preview
+@Composable
+fun MemberInfoCardPreview() {
+    val navController = rememberNavController() // 임시 NavController 생성
+    MemberInfoCard(
+        memberInfo = MemberInfoEntity(
+            1,
+            "nickname",
+            1,
+            1,
+            1,
+            "",
+            "statusMessage",
+            1,
+            1,
+        ),
+        navController = navController
+    )
+}

--- a/app/src/main/java/com/cokiri/coinkiri/presentation/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/cokiri/coinkiri/presentation/profile/ProfileScreen.kt
@@ -50,7 +50,6 @@ fun ProfileScreen(
     val sheetState = rememberModalBottomSheetState()
     var showBottomSheet by remember { mutableStateOf(false) }
     val loginUiState by loginViewModel.loginUiState.collectAsStateWithLifecycle()
-
     val memberInfo by profileViewModel.memberInfo.collectAsStateWithLifecycle()
 
     LaunchedEffect(loginUiState) {
@@ -98,12 +97,10 @@ fun ProfileScreen(
                 )
             }
             Column(modifier = Modifier.padding(it)) {
-                // Profile screen content goes here
-                memberInfo?.let { it1 ->
-                    Text(
-                        text = it1.nickname
-                    )
-                }
+                MemberInfoCard(
+                    memberInfo = memberInfo,
+                    navController = navController
+                )
             }
         }
     )
@@ -155,3 +152,4 @@ fun ModalBottomSheetBtn(
         )
     }
 }
+

--- a/app/src/main/java/com/cokiri/coinkiri/ui/navigation/GraphProfile.kt
+++ b/app/src/main/java/com/cokiri/coinkiri/ui/navigation/GraphProfile.kt
@@ -4,7 +4,9 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import com.cokiri.coinkiri.presentation.login.LoginViewModel
+import com.cokiri.coinkiri.presentation.profile.FollowScreen
 import com.cokiri.coinkiri.presentation.profile.ProfileScreen
+import com.cokiri.coinkiri.util.FOLLOW
 import com.cokiri.coinkiri.util.PROFILE
 
 fun NavGraphBuilder.profileNavGraph(
@@ -17,4 +19,9 @@ fun NavGraphBuilder.profileNavGraph(
             navController = navController
         )
     }
+
+    composable(FOLLOW) {
+        FollowScreen(navController)
+    }
+
 }

--- a/app/src/main/java/com/cokiri/coinkiri/ui/theme/Color.kt
+++ b/app/src/main/java/com/cokiri/coinkiri/ui/theme/Color.kt
@@ -16,3 +16,4 @@ val CoinkiriPointGreen = Color(0xFF829F8A)
 val CoinkiriGreen = Color(0xFFE0E5E0)
 val CoinkiriBackground = Color(0xFFF8F8F8)  // 앱의 배경 색
 
+val kakaoColor = Color(0xFFFCEC5C)

--- a/app/src/main/java/com/cokiri/coinkiri/util/Const.kt
+++ b/app/src/main/java/com/cokiri/coinkiri/util/Const.kt
@@ -6,3 +6,5 @@ const val POST = "POST"
 const val HOME = "HOME"
 const val PRICE = "PRICE"
 const val PROFILE = "PROFILE"
+
+const val FOLLOW = "FOLLOW"


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #20

## 🔑 Key Changes

1. 내용
    - 백엔드 서버로부터 유저정보를 받아 roomdb에 저장 후 유저프로필 화면에서 해당 정보 확인가능(동기화 미구현)
    - 유저의 팔로워/팔로잉 확인가능하도록 화면 추가(임시)

## 📸 Screenshot


## 📢 To Reviewers
-
